### PR TITLE
Access lease fix typo

### DIFF
--- a/resources/access_lease.py
+++ b/resources/access_lease.py
@@ -59,7 +59,7 @@ class AccessLease(Dome9Resource):
 		:rtype  AwsAccessLeasePost
 
 		"""
-		route = f'{AccessLeaseConsts.ACCESS_Lease.value}/{AccessLeaseConsts.AWS_CLOUD_ACCOUNT.value}'
+		route = f'{AccessLeaseConsts.ACCESS_LEASE.value}/{AccessLeaseConsts.AWS_CLOUD_ACCOUNT.value}'
 		return self._post(route=route, body=body)
 
 	def get_all(self) -> Dict:
@@ -70,7 +70,7 @@ class AccessLease(Dome9Resource):
 		:rtype  AccessLeasesGrouped
 
 		"""
-		return self._get(route=AccessLeaseConsts.ACCESS_Lease.value)
+		return self._get(route=AccessLeaseConsts.ACCESS_LEASE.value)
 
 	def terminate_lease(self, lease_id: str) -> None:
 		"""Terminate lease
@@ -80,5 +80,5 @@ class AccessLease(Dome9Resource):
 		:type lease_id: str
 
 		"""
-		route = f'{AccessLeaseConsts.ACCESS_Lease.value}/{lease_id}'
+		route = f'{AccessLeaseConsts.ACCESS_LEASE.value}/{lease_id}'
 		return self._delete(route=route)

--- a/resources/ip_list.py
+++ b/resources/ip_list.py
@@ -8,7 +8,7 @@ from dome9 import Dome9Resource, Client, BaseDataclassRequest, APIUtils
 
 
 class IpListConsts(Enum):
-	MAIN_ROUTE = 'IpList'
+	IP_LIST = 'IpList'
 
 
 @dataclass
@@ -64,7 +64,7 @@ class IpList(Dome9Resource):
 
 		"""
 
-		return self._post(route=IpListConsts.MAIN_ROUTE.value, body=body)
+		return self._post(route=IpListConsts.IP_LIST.value, body=body)
 
 	def get(self, ip_list_id: int) -> Dict:
 		"""Get an IP List by ID
@@ -76,7 +76,7 @@ class IpList(Dome9Resource):
 		:rtype  IpList
 
 		"""
-		route = f'{IpListConsts.MAIN_ROUTE.value}/{ip_list_id}'
+		route = f'{IpListConsts.IP_LIST.value}/{ip_list_id}'
 
 		return self._get(route=route)
 
@@ -90,7 +90,7 @@ class IpList(Dome9Resource):
 		:type   body: IpListRequest
 
 		"""
-		route = f'{IpListConsts.MAIN_ROUTE.value}/{ip_list_id}'
+		route = f'{IpListConsts.IP_LIST.value}/{ip_list_id}'
 
 		return self._put(route=route, body=body)
 
@@ -102,6 +102,6 @@ class IpList(Dome9Resource):
 		:type  ip_list_id: int
 
 		"""
-		route = f'{IpListConsts.MAIN_ROUTE.value}/{ip_list_id}'
+		route = f'{IpListConsts.IP_LIST.value}/{ip_list_id}'
 
 		return self._delete(route=route)

--- a/resources/role.py
+++ b/resources/role.py
@@ -6,7 +6,7 @@ from dome9 import Dome9Resource, Client, BaseDataclassRequest
 
 
 class RoleConsts(Enum):
-	MAIN_ROUTE = 'role'
+	ROLE = 'role'
 
 
 @dataclass
@@ -95,7 +95,7 @@ class Role(Dome9Resource):
 		:rtype  Role
 
 		"""
-		return self._post(route=RoleConsts.MAIN_ROUTE.value, body=body)
+		return self._post(route=RoleConsts.ROLE.value, body=body)
 
 	def get(self, role_id: str = '') -> Union[Dict, List[Dict]]:
 		"""Get the specific role with the specified id
@@ -106,7 +106,7 @@ class Role(Dome9Resource):
 		:rtype  Role
 
 		"""
-		route = f'{RoleConsts.MAIN_ROUTE.value}/{role_id}'
+		route = f'{RoleConsts.ROLE.value}/{role_id}'
 		return self._get(route=route)
 
 	def update(self, role_id: str, body: UpdateRole) -> Dict:
@@ -120,7 +120,7 @@ class Role(Dome9Resource):
 		:rtype  Role
 
 		"""
-		route = f'{RoleConsts.MAIN_ROUTE.value}/{role_id}'
+		route = f'{RoleConsts.ROLE.value}/{role_id}'
 		return self._put(route=route, body=body)
 
 	def delete(self, role_id: str) -> None:
@@ -131,5 +131,5 @@ class Role(Dome9Resource):
 		:return: None
 
 		"""
-		route = f'{RoleConsts.MAIN_ROUTE.value}/{role_id}'
+		route = f'{RoleConsts.ROLE.value}/{role_id}'
 		return self._delete(route=route)


### PR DESCRIPTION
- Replacing all `Access_Lease` with `ACCESS_LEASE`
- Replacing `MAIN_ROUE` consts with the appropriate name 